### PR TITLE
Add a spec example project

### DIFF
--- a/spec/.gitignore
+++ b/spec/.gitignore
@@ -1,0 +1,13 @@
+/target
+/classes
+/checkouts
+profiles.clj
+#pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/
+.cpcache/

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,43 @@
+# Spec Graal
+
+Tests for using the Clojure spec.alpha library with GraalVM **native-image**.
+
+## Usage
+
+Currently testing:
+
+    [org.clojure/spec.alpha "0.2.187"]
+
+We can successfully build the native image at `target/spec-graal` with:
+
+    $ lein do clean, uberjar, native, run-native
+
+The following is equivalent:
+
+    $ lein do clean, uberjar
+    $ native-image \
+          --report-unsupported-elements-at-runtime \
+          --no-server \
+          --initialize-at-build-time \
+          -jar ./target/spec-graal.jar \
+          -H:Name=./target/spec-graal
+
+Using tools.deps, the native image can be built as follows:
+
+    $ clojure -A:depstar -m hf.depstar.uberjar target/spec-graal.jar -C -m spec-graal.main
+    $ native-image \
+          --report-unsupported-elements-at-runtime \
+          --no-server \
+          --initialize-at-build-time \
+          -jar ./target/spec-graal.jar \
+          -H:Name=./target/spec-graal
+
+Speed difference:
+
+    $ time ./target/spec-graal
+    Hello GraalVM with Spec! Btw, 'Spec Graal' is a valid ::title.
+    0.00 real         0.00 user         0.00 sys
+
+    $ time java -jar ./target/spec-graal.jar
+    Hello GraalVM with Spec! Btw, 'Spec Graal' is a valid ::title.
+    0.95 real         1.86 user         0.19 sys

--- a/spec/deps.edn
+++ b/spec/deps.edn
@@ -1,0 +1,7 @@
+{:deps {org.clojure/clojure {:mvn/version "1.10.1"}
+        org.clojure/spec.alpha {:mvn/version "0.2.187"}}
+ :paths ["src"]
+ :aliases
+ {:depstar
+  {:extra-deps
+   {seancorfield/depstar {:mvn/version "1.0.94"}}}}}

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>spec-graal</groupId>
+  <artifactId>spec-graal</artifactId>
+  <version>0.1.0</version>
+  <name>spec-graal</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.clojure</groupId>
+      <artifactId>clojure</artifactId>
+      <version>1.10.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.clojure</groupId>
+      <artifactId>spec.alpha</artifactId>
+      <version>0.2.187</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <sourceDirectory>src</sourceDirectory>
+  </build>
+  <repositories>
+    <repository>
+      <id>clojars</id>
+      <url>https://repo.clojars.org/</url>
+    </repository>
+  </repositories>
+</project>

--- a/spec/project.clj
+++ b/spec/project.clj
@@ -1,0 +1,20 @@
+(defproject spec-graal "0.1.0-SNAPSHOT"
+
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/spec.alpha "0.2.187"]]
+
+  :main spec-graal.main
+
+  :uberjar-name "spec-graal.jar"
+
+  :profiles {:uberjar {:aot :all}
+             :dev {:plugins [[lein-shell "0.5.0"]]}}
+
+  :aliases
+  {"native"
+   ["shell"
+    "native-image" "--report-unsupported-elements-at-runtime" "--no-server"
+    "--initialize-at-build-time"
+    "-jar" "./target/${:uberjar-name:-${:name}-${:version}-standalone.jar}"
+    "-H:Name=./target/${:name}"]
+   "run-native" ["shell" "./target/${:name}"]})

--- a/spec/src/spec_graal/main.clj
+++ b/spec/src/spec_graal/main.clj
@@ -1,0 +1,11 @@
+(ns spec-graal.main
+  (:gen-class)
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::title string?)
+
+(defn -main []
+  (let [title "Spec Graal"]
+    (printf "Hello GraalVM with Spec! Btw, '%s' %s a valid ::title.\n"
+            title (if (s/valid? ::title title) "is" "is NOT")))
+  (flush))


### PR DESCRIPTION
Provides a minimal example of how to build a GraalVM native image using lein or tools.deps for a project requiring spec.alpha 0.2.187

- Resolves https://github.com/BrunoBonacci/graalvm-clojure/issues/3