### PR TITLE
Explicitly use graalvm env in project

### DIFF
--- a/aws-api-s3/project.clj
+++ b/aws-api-s3/project.clj
@@ -1,12 +1,12 @@
-(defproject aws-api-s3 "0.1.0-SNAPSHOT"
+(def graalvm-home (System/getenv "GRAALVM_HOME"))
 
+(defproject aws-api-s3 "0.1.0-SNAPSHOT"
   :dependencies [[org.clojure/clojure         "1.10.2-rc1"]
                  [com.cognitect.aws/api       "0.8.484"]
                  [com.cognitect.aws/endpoints "1.1.11.926"]
                  [com.cognitect.aws/s3        "810.2.817.0"]]
-
+  :graalvm-home ~graalvm-home
   :main simple.main
-
   :uberjar-name "simple-main.jar"
   :profiles {:uberjar {:aot :all}
              :dev {:plugins [[lein-shell "0.5.0"]]}}
@@ -15,18 +15,25 @@
   {"native-config"
    ["shell"
     ;; run the application to infer the build configuration
-    "java" "-agentlib:native-image-agent=config-output-dir=./target/config/"
+    "${:graalvm-home}/bin/java"
+    "-agentlib:native-image-agent=config-output-dir=./target/config/"
     "-jar" "./target/${:uberjar-name:-${:name}-${:version}-standalone.jar}"]
 
    "native"
    ["shell"
-    "native-image" "--report-unsupported-elements-at-runtime" "--no-server" "--no-fallback"
+    "${:graalvm-home}/bin/native-image"
+    "--report-unsupported-elements-at-runtime"
+    "--no-server"
+    "--no-fallback"
     "-H:+PrintClassInitialization"
     "-H:ConfigurationFileDirectories=./target/config/"
     "--initialize-at-build-time"
     "--allow-incomplete-classpath"
-    "--enable-http" "--enable-https" "--enable-all-security-services"
+    "--enable-http"
+    "--enable-https"
+    "--enable-all-security-services"
     "-jar" "./target/${:uberjar-name:-${:name}-${:version}-standalone.jar}"
     "-H:Name=./target/${:name}"]
 
-   "run-native" ["shell" "./target/${:name}"]})
+   "run-native"
+   ["shell" "./target/${:name}"]})

--- a/sample-project/README.md
+++ b/sample-project/README.md
@@ -2,6 +2,13 @@
 
 Use this project as template for testing a specific library with GraalVM **native-image**
 
+## Pre-requisite
+
+- Valid installation of GRAALVM 
+- Install `native-image` at least once e.g. `$GRAALVM_HOME/bin/gu native-image`
+- Setup the env for GRAALVM_HOME e.g. `export GRAALVM_HOME=/path/to/your/graalvm-installation`
+- Valid Java installation e.g. `export JAVA_HOME=/path/to/your/java-installation`
+
 ## Usage
 
 Currently testing:
@@ -11,6 +18,5 @@ Currently testing:
 Test with:
 
     lein do clean, uberjar, native, run-native
-
 
 Add any info might be useful for the reader.

--- a/sample-project/project.clj
+++ b/sample-project/project.clj
@@ -1,22 +1,29 @@
-(defproject sample-project "0.1.0-SNAPSHOT"
+(def graalvm-home (System/getenv "GRAALVM_HOME"))
 
+(defproject sample-project "0.1.0-SNAPSHOT"
   :dependencies [[org.clojure/clojure "1.10.1"]
                  ;; add the library here
                  ]
-
   :main simple.main
-
   :uberjar-name "simple-main.jar"
-
   :profiles {:uberjar {:aot :all}
              :dev {:plugins [[lein-shell "0.5.0"]]}}
-
   :aliases
-  {"native"
+  {"native-config"
    ["shell"
-    "native-image" "--report-unsupported-elements-at-runtime" "--no-server"
+    ;; run the application to infer the build configuration
+    "${:graalvm-home}/bin/java"
+    "-agentlib:native-image-agent=config-output-dir=./target/config/"
+    "-jar" "./target/${:uberjar-name:-${:name}-${:version}-standalone.jar}"]
+
+   "native"
+   ["shell"
+    "native-image"
+    "--report-unsupported-elements-at-runtime"
+    "--no-server"
     "--initialize-at-build-time"
     "-jar" "./target/${:uberjar-name:-${:name}-${:version}-standalone.jar}"
     "-H:Name=./target/${:name}"]
 
-   "run-native" ["shell" "./target/${:name}"]})
+   "run-native"
+   ["shell" "./target/${:name}"]})

--- a/sample-project/project.clj
+++ b/sample-project/project.clj
@@ -1,7 +1,7 @@
 (def graalvm-home (System/getenv "GRAALVM_HOME"))
 
 (defproject sample-project "0.1.0-SNAPSHOT"
-  :dependencies [[org.clojure/clojure "1.10.1"]
+  :dependencies [[org.clojure/clojure "1.10.2-rc1"]
                  ;; add the library here
                  ]
   :main simple.main


### PR DESCRIPTION
Hi @BrunoBonacci 

Thanks for creating the library for us all.
I like to add this PR to make it easier to compile and build native-image with JDK/GraalVM.
It introduce the variable/env `GRAALVM_HOME` to `project.clj` and use the variable with `lean-shell` script.

I tested this out with the `aws-s3-api` example and it works very well.

This make it possible to build uberjar with other JDK (e.g. non-graalvm) while ensure that the `native-config` and `native-image` steps are using this env as part of the command.

Also I updated the sample-project with basic instruction and the same config for other to use.

Best,
Burin