### PR TITLE
Datascripts works with clojure 1.10.2

### DIFF
--- a/datascript/README.md
+++ b/datascript/README.md
@@ -6,7 +6,8 @@ Testing whether [datascript](https://github.com/tonsky/datascript) library can b
 
 Currently testing:
 
-    [datascript "0.18.10"]
+    [datascript "1.0.3"]
+    [org.clojure/clojure "1.10.2"]
 
 Test with:
 
@@ -17,17 +18,4 @@ Test with:
 
 ## Notes
 - To get datascript to compile a [reflect-config](./reflect-config.json) file is necessary. Once this is available it compiles and runs. 
-- Datascript does not compile at all when using clojure 1.10.
-```
-Warning: Aborting stand-alone image build. unbalanced monitors: mismatch at monitorexit, 3|LoadField#lockee__5436__auto__ != 96|LoadField#lockee__5436__auto__
-Detailed message:
-Call path from entry point to clojure.spec.gen.alpha$dynaload$fn__2628.invoke(): 
-	at clojure.spec.gen.alpha$dynaload$fn__2628.invoke(alpha.clj:21)
-	at clojure.lang.AFn.run(AFn.java:22)
-	at java.lang.Thread.run(Thread.java:748)
-	at com.oracle.svm.core.thread.JavaThreads.threadStartRoutine(JavaThreads.java:527)
-	at com.oracle.svm.core.posix.thread.PosixJavaThreads.pthreadStartRoutine(PosixJavaThreads.java:193)
-	at com.oracle.svm.core.code.IsolateEnterStub.PosixJavaThreads_pthreadStartRoutine_e1f4a8c0039f8337338252cd8734f63a79b5e3df(generated:0)
-
-Warning: Use -H:+ReportExceptionStackTraces to print stacktrace of underlying exception
 ```

--- a/datascript/project.clj
+++ b/datascript/project.clj
@@ -1,8 +1,7 @@
 (defproject datascript "0.1.0-SNAPSHOT"
 
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [datascript "0.18.10"]
-                 ]
+  :dependencies [[org.clojure/clojure "1.10.2"]
+                 [datascript "1.0.3"]]
 
   :main simple.main
 


### PR DESCRIPTION
With graalvm-ce-java8-20.2.0

```
$ target/datascript
([:red [30 40 50] [10 20 30]] [:blue [7 8] [7 8]])
Hello GraalVM.
```

Output

```
Compiling simple.main
Created /Users/jeroen/Projects/Github/graalvm-clojure/datascript/target/datascript-0.1.0-SNAPSHOT.jar
Created /Users/jeroen/Projects/Github/graalvm-clojure/datascript/target/simple-main.jar
[./target/datascript:42257]    classlist:   2,662.68 ms,  1.49 GB
[./target/datascript:42257]        (cap):   2,739.74 ms,  1.49 GB
[./target/datascript:42257]        setup:   8,772.37 ms,  1.49 GB
[./target/datascript:42257]     (clinit):     166.56 ms,  2.18 GB
[./target/datascript:42257]   (typeflow):   8,450.98 ms,  2.18 GB
[./target/datascript:42257]    (objects):   7,303.24 ms,  2.18 GB
[./target/datascript:42257]   (features):     328.84 ms,  2.18 GB
[./target/datascript:42257]     analysis:  37,140.81 ms,  2.18 GB
[./target/datascript:42257]     universe:     628.34 ms,  2.18 GB
[./target/datascript:42257]      (parse):   2,419.50 ms,  2.19 GB
[./target/datascript:42257]     (inline):   1,962.76 ms,  2.43 GB
[./target/datascript:42257]    (compile):  14,987.94 ms,  3.41 GB
[./target/datascript:42257]      compile:  35,348.16 ms,  3.41 GB
[./target/datascript:42257]        image:   2,185.15 ms,  3.44 GB
[./target/datascript:42257]        write:     718.46 ms,  3.44 GB
[./target/datascript:42257]      [total]: 122,739.52 ms,  3.44 GB
```