### PR TITLE
Fix broken links to native image docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ More libraries to come (*PRs are welcome*).
 
 Interesting GraalVM documentation to build native-images:
 
-  - Understand [Class Initialization in Native Image](https://github.com/oracle/graal/blob/master/substratevm/CLASS-INITIALIZATION.md)
-  - [Assisted Configuration of Native Image Builds](https://github.com/oracle/graal/blob/master/substratevm/CONFIGURE.md)
-  - [URL Protocols on Substrate VM](https://github.com/oracle/graal/blob/master/substratevm/URL-PROTOCOLS.md) for `http` and `https`
-  - [JCA Security Services on Substrate VM](https://github.com/oracle/graal/blob/master/substratevm/JCA-SECURITY-SERVICES.md)
+  - Understand [Class Initialization in Native Image](https://github.com/oracle/graal/blob/master/substratevm/ClassInitialization.md)
+  - [Assisted Configuration of Native Image Builds](https://github.com/oracle/graal/blob/master/substratevm/BuildConfiguration.md#assisted-configuration-of-native-image-builds)
+  - [URL Protocols on Substrate VM](https://github.com/oracle/graal/blob/master/substratevm/URLProtocols.md) for `http` and `https`
+  - [JCA Security Services on Substrate VM](https://github.com/oracle/graal/blob/master/substratevm/JCASecurityServices.md)
 
 
 ## How to contribute


### PR DESCRIPTION
The links to Oracle's native image documentation were broken by these commits:

- https://github.com/oracle/graal/commit/176c01a88cd3d9767b6a26c434a8c62971258924#diff-cf99dae8e37c285d8fc01e5eef559090983afc091cbc2c9c4115f191c95bfb9b
- https://github.com/oracle/graal/commit/176c01a88cd3d9767b6a26c434a8c62971258924#diff-8339839fc17c6b11c6baa3e35b0ee0d3c59006198a232f755091dc8259590fc6
- https://github.com/oracle/graal/commit/24fe0c62c92b8cf9455126124d89315e207aaae6#diff-852aa4de16767c2bd78b3cb53021cd69b8bf6a7da3488f423d85afbb8963e869
- https://github.com/oracle/graal/commit/13f8eac5b3e5497872038c42a48ae019d0e60a70#diff-dbb460466cf6fe74075a9dc7bae22018a1e51b9ba7dce7257a2d4e9ffff705aa

This patch updates the links; for the "Assisted Configuration..." link, I've added an anchor so the topic heading is easier to find.