### PR TITLE
add lacinia

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Here the list of libraries tested:
 | :white_check_mark: | [hiccup](./hiccup)                                   | Fast library for rendering HTML in Clojure                          |                                |
 | :white_check_mark: | [http-kit](./http-kit)                               | Web server and server                                               |                                |
 | :white_check_mark: | [integrant](./integrant)                             | Alternative to mount, component etc.                                |                                |
+| :white_check_mark: | [lacinia](./lacinia)                                 | A GraphQL server implementation in pure Clojure                     |                                |
 | :white_check_mark: | [loom](./loom)                                       | A Graph manipulation and computation library.                       |                                |
 | :x:                | [monger](./monger)                                   | An idiomatic Clojure MongoDB driver with sane defaults              |                                |
 | :white_check_mark: | [μ/log](./mulog)                                     | Event logging system                                                |                                |

--- a/lacinia/.gitignore
+++ b/lacinia/.gitignore
@@ -1,0 +1,15 @@
+/target
+/classes
+/checkouts
+/reports
+/clinit.d
+profiles.clj
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+/.prepl-port
+.hgignore
+.hg/

--- a/lacinia/Makefile
+++ b/lacinia/Makefile
@@ -1,0 +1,23 @@
+.PHONY: all test deps
+
+PROJECT = lacinia
+EXE = ./target/$(PROJECT)
+JAR = ./target/simple-main.jar
+
+all: test
+
+test: $(EXE)
+	lein run-native
+
+deps: clean $(JAR)
+	-java -jar -agentlib:native-image-agent=config-output-dir=clinit.d $(JAR)
+	@echo Configuration files written to $$(pwd)/clinit.d
+
+clean:
+	-lein clean
+
+$(JAR):
+	@if [ ! -f $@ ]; then lein uberjar; fi
+
+$(EXE): $(JAR)
+	@if [ ! -f $@ ]; then lein native; fi

--- a/lacinia/README.md
+++ b/lacinia/README.md
@@ -1,0 +1,56 @@
+# lacinia
+
+This project generates a native binary image of a simple program using
+[lacinia], a GraphQL server implementation in pure Clojure
+
+## Usage
+
+Configure with:
+
+    make deps
+
+Re-run this step after changing any project dependencies.
+
+The `simple.schema` class reads files from disk, so `native-image` must
+be run with the `-H:ResourceConfigurationFiles` option set to
+`clinit.d/resource-config.json` (as `project.clj` should be doing already).
+
+More information [here](https://www.graalvm.org/reference-manual/native-image/Resources).
+
+Test with:
+
+    make
+
+The program will print the results of a simple GraphQL query.
+
+## Results
+
+_simple.main_
+- `[com.walmartlabs.lacinia :as lacinia]` :white_check_mark:
+
+_simple.schema_
+- `[com.walmartlabs.lacinia.util :as util]` :white_check_mark:
+- `[com.walmartlabs.lacinia.schema :as schema]` :white_check_mark:
+
+## Notes
+
+- **a GraalVM SDK from the [21.x or later series], targeting [Java 11 or later], is required**
+
+- `clojure` 1.10.1 (and older) is affected by [this known issue];
+   the minimum required version is 1.10.2
+
+- some unidentified transitive dependency is calling into the Java UI
+  widget libraries, so:
+
+    + Linux targets will need the [FreeType 2 development package],
+      in addition to the [required build dependencies][]
+
+    + expect a fat binary (~70 Mb on a Linux desktop, or ~55 Mb on Windows)
+
+
+[lacinia]: https://github.com/walmartlabs/lacinia
+[this known issue]: https://github.com/oracle/graal/issues/1681
+[required build dependencies]: https://www.graalvm.org/reference-manual/native-image/#prerequisites
+[FreeType 2 development package]: https://pkgs.org/download/libfreetype6-dev
+[21.x or later series]: https://github.com/oracle/graal/issues/2842#issuecomment-748628763
+[Java 11 or later]: https://github.com/oracle/graal/issues/2842#issuecomment-802923557

--- a/lacinia/make.cmd
+++ b/lacinia/make.cmd
@@ -1,0 +1,23 @@
+@echo off
+@rem first, generate dependency info:
+@rem  make deps
+@rem . . . then build and run:
+@rem  make
+SETLOCAL EnableExtensions
+SET "JAR=target\simple-main.jar"
+
+IF "%1" == "clean" (
+  lein clean
+  GOTO END
+)
+
+IF "%1" == "deps" (
+  lein do clean, uberjar
+  java -jar -agentlib:native-image-agent=config-output-dir=clinit.d "%JAR%"
+  echo. Configuration files written to %CD%/clinit.d
+) ELSE (
+  lein do uberjar, native, run-native
+)
+
+:END
+ENDLOCAL

--- a/lacinia/project.clj
+++ b/lacinia/project.clj
@@ -1,0 +1,26 @@
+(defproject lacinia "0.1.0-SNAPSHOT"
+
+  :dependencies [[org.clojure/clojure "1.10.3"]
+                 [com.walmartlabs/lacinia "1.0"]]
+
+  :main simple.main
+
+  :uberjar-name "simple-main.jar"
+
+  :profiles {:uberjar {:aot :all}
+             :dev {:plugins [[lein-shell "0.5.0"]]}}
+
+  :aliases
+  {"native"
+   ["shell"
+    "native-image" "--report-unsupported-elements-at-runtime" "--no-server" "--no-fallback"
+    "--initialize-at-build-time"
+    "--initialize-at-run-time=java.awt,javax.accessibility,javax.swing,sun.awt,sun.font,sun.java2d,sun.swing"
+    "--trace-class-initialization=java.awt.Toolkit,java.awt.Font,java.awt.RenderingHints,sun.awt.AWTAccessor,sun.awt.SunHints,sun.awt.UNIXToolkit,sun.awt.AppContext,sun.awt.OSInfo,sun.awt.X11.XToolkit,sun.awt.SunToolkit,sun.awt.X11GraphicsEnvironment"
+    "-jar" "./target/${:uberjar-name:-${:name}-${:version}-standalone.jar}"
+    "-Djava.awt.headless=true"
+    "-H:ResourceConfigurationFiles=clinit.d/resource-config.json"
+    "-H:+ReportExceptionStackTraces"
+    "-H:Name=./target/${:name}"]
+
+   "run-native" ["shell" "./target/${:name}"]})

--- a/lacinia/resources/data.edn
+++ b/lacinia/resources/data.edn
@@ -1,0 +1,70 @@
+{:books
+ [{:id "6a2b1cf-d34f-a316-d3aac3b24fca"
+   :title "Hello GraalVM"
+   :authors #{"5b5fa1c3-e220-da2c-2fcd-3dcc6709cf31b"}
+   :published 2021
+   :subject #{"JVM" "native-image"}}
+  {:id "d6c6d15-5f56-b216-1def461745ec"
+   :title "Design Patterns: Elements of Reusable Object-Oriented Software"
+   :authors #{"34ead153-123d-45e9-d153-089c6709cf3e" "afa5b6f1-344d-11e9-a414-719c6709cf3ee" "ef345def-dfe0-aee9-d153-abc5c6709cf3e" "bac09fef-d4e0-bcd9-f200-e345c6709cf5f"}
+   :published 1994
+   :subject #{"OOP" "patterns" "design"}}
+  {:id "5f56d15-b216-d6c6-5f3c647245f0"
+   :title "The Art of the Metaobject Protocol"
+   :authors #{"dc3e15e0-decd-0c2e-3cab-970c670902c23"}
+   :published 1991
+   :subject #{"Common Lisp" "patterns" "design"}}
+  {:id "f2e41dd-e1ff-a3cb-3c461a7245c1"
+   :title "Agile Software Development, Principles, Patterns, and Practices"
+   :authors #{"0c2e15e0-3cd1-c4d2-b4e1-23c670902ab1a"}
+   :published 2002
+   :subject #{"agile" "design"}}
+  {:id "f2e41dd-e1ff-a3cb-3c461a7245c1"
+   :title "Clean Code: A Handbook of Agile Software Craftsmanship"
+   :authors #{"0c2e15e0-3cd1-c4d2-b4e1-23c670902ab1a"}
+   :published 2008
+   :subject #{"refactoring" "design"}}
+  {:id "a414b6f0-afa5-11e9-430e-719c6709cf3e"
+   :title "The C Programming Language",
+   :authors #{"93fcd21d-a2d3-021d-c01a-3c54d6709cf0c" "f343a09a-2c3d-c10e-4bc2-c421d6709c2cb"}
+   :published 1978
+   :subject #{"ISO C" "systems" "language specification"}}]
+
+ :authors
+ [{:id "34ead153-123d-45e9-d153-089c6709cf3e"
+   :first_name "Erich"
+   :last_name "Gamma"
+   :from 1961}
+  {:id "0c2e15e0-3cd1-c4d2-b4e1-23c670902ab1a"
+   :first_name "Robert"
+   :last_name "Martin"
+   :from 1952}
+  {:id "dc3e15e0-decd-0c2e-3cab-970c670902c23"
+   :first_name "Gregor"
+   :last_name "Kiczales"
+   :from 1961}
+  {:id "afa5b6f1-344d-11e9-a414-719c6709cf3ee"
+   :first_name "Richard"
+   :last_name "Helm"}
+  {:id "ef345def-dfe0-aee9-d153-abc5c6709cf3e"
+   :first_name "Ralph"
+   :last_name "Johnson"
+   :from 1955}
+  {:id "bac09fef-d4e0-bcd9-f200-e345c6709cf5f"
+   :first_name "John"
+   :last_name "Vlissides"
+   :from 1961
+   :until 2005}
+  {:id "93fcd21d-a2d3-021d-c01a-3c54d6709cf0c"
+   :first_name "Brian"
+   :last_name "Kernighan"
+   :from 1942}
+  {:id "f343a09a-2c3d-c10e-4bc2-c421d6709c2cb"
+   :first_name "Dennis"
+   :last_name "Ritchie"
+   :from 1941
+   :until 2011}
+  {:id "5b5fa1c3-e220-da2c-2fcd-3dcc6709cf31b"
+   :first_name "Oracle"
+   :last_name "Corporation"
+   :from 1995}]}

--- a/lacinia/resources/schema.edn
+++ b/lacinia/resources/schema.edn
@@ -1,0 +1,28 @@
+{:objects
+ {:Author
+  {:fields
+   {:id {:type (non-null ID)}
+    :first_name {:type (non-null String)}
+    :last_name {:type (non-null String)}
+    :from {:type Int
+           :description "Year of birth, if known."}
+    :until {:type Int
+            :description "Year of death, if applicable."}}}
+  :Book
+  {:fields
+   {:id {:type (non-null ID)}
+    :title {:type (non-null String)}
+    :authors {:type (non-null (list :Author))
+              :description "A book must have one or more authors."
+              :resolve :Book/authors}
+    :published {:type Int
+                :description "Year of first publication."}
+    :subject {:type (list String)
+             :resolve :Book/subject}}}}
+
+ :queries
+ {:book_by_id
+  {:type :Book
+   :args
+   {:id {:type ID}}
+   :resolve :query/book-by-id}}}

--- a/lacinia/src/simple/main.clj
+++ b/lacinia/src/simple/main.clj
@@ -1,0 +1,28 @@
+(ns simple.main
+  (:require
+    [simple.schema :as s]
+    [com.walmartlabs.lacinia :as lacinia]
+    [clojure.pprint :refer [pprint]])
+  (:gen-class))
+
+(defn -main []
+  (let [schema (s/load-schema)
+        query "book_by_id"
+        book-id "6a2b1cf-d34f-a316-d3aac3b24fca"
+        q-str (format "{
+                          %s(id: \"%s\") {
+                              title
+                              authors {
+                                  first_name
+                                  last_name
+                              }
+                              subject
+                          }
+                       }"
+                      query
+                      book-id)
+        {:keys [data errors]} (lacinia/execute schema q-str nil nil)]
+    (-> (if (nil? errors)
+          ((keyword query) data)
+          errors)
+        pprint)))

--- a/lacinia/src/simple/schema.clj
+++ b/lacinia/src/simple/schema.clj
@@ -1,0 +1,44 @@
+(ns simple.schema
+  "Adapted from this tutorial:
+  https://lacinia.readthedocs.io/en/latest/tutorial/designer-data.html#id4"
+  (:require
+    [clojure.java.io :as io]
+    [com.walmartlabs.lacinia.util :as util]
+    [com.walmartlabs.lacinia.schema :as schema]
+    [clojure.edn :as edn])
+  (:gen-class))
+
+(defn- ->entity
+  [data entity-name]
+  (->> (get data entity-name)
+       (reduce #(assoc %1 (:id %2) %2) {})))
+
+(defn- resolve-book-authors
+  [authors-map context args book]
+  (->> (:authors book) (map authors-map)))
+
+(defn- resolve-book-subject
+  [_ context args book]
+  (:subject book))
+
+(defn- resolve-book-by-id
+  [books context args value]
+  (let [{:keys [id]} args]
+    (get books id)))
+
+(defn- resolver-map []
+  (let [data (-> (io/resource "data.edn")
+                 slurp
+                 edn/read-string)
+        books-map (->entity data :books)
+        authors-map (->entity data :authors)]
+    {:Book/authors (partial resolve-book-authors authors-map)
+     :Book/subject (partial resolve-book-subject nil)
+     :query/book-by-id (partial resolve-book-by-id books-map)}))
+
+(defn load-schema []
+  (-> (io/resource "schema.edn")
+      slurp
+      edn/read-string
+      (util/attach-resolvers (resolver-map))
+      schema/compile))


### PR DESCRIPTION
I've been able to compile [lacinia] in these environments:

| *OS*                   | *Host compiler*                     | *GraalVM version*                            |
|:-----------------------|:------------------------------------|:---------------------------------------------|
| [Ubuntu 20.04]         | gcc 10.3.0-1ubuntu1~20.04           | CE 21.2.0 (build 11.0.12+6-jvmci-21.2-b08)   |
| Debian 10              | gcc 8.3.0 (Debian 8.3.0-6)          | CE 21.1.0 (build 11.0.11+8-jvmci-21.1-b05)   |
| Windows 10.0.19042.985 | MSVC 19.28.29337 for x64                 | CE 21.0.0.2 (build 11.0.10+8-jvmci-21.0-b06) |

Some unused parts of the library depend on AWT classes that might not compile on GraalVMs in [the 20.x series],
and clojure 1.10.1 (or older) doesn't work because of [this known issue].

There's a Makefile to simplify the configuration (basically just generating a `resource-config.json`).

Provided your toolchain dates from this year, everything should work as expected.

[lacinia]: https://github.com/walmartlabs/lacinia
[the 20.x series]: https://github.com/oracle/graal/issues/2842#issuecomment-748628763
[this known issue]: https://github.com/oracle/graal/issues/1681
[Ubuntu 20.04]: https://gist.github.com/rdipardo/271c8c1476bd183fb3c4e45a4474b9f9
